### PR TITLE
Make it compatible with Pydantic V2

### DIFF
--- a/rdbbeat/controller.py
+++ b/rdbbeat/controller.py
@@ -13,7 +13,9 @@ from rdbbeat.db.models import CrontabSchedule, PeriodicTask
 from rdbbeat.exceptions import PeriodicTaskNotFound
 
 
-def get_crontab_schedule(session: Session, schedule: Schedule) -> CrontabSchedule:
+def get_crontab_schedule(
+    session: Session, schedule: Schedule
+) -> CrontabSchedule:
     crontab = (
         session.query(CrontabSchedule)
         .where(
@@ -28,7 +30,7 @@ def get_crontab_schedule(session: Session, schedule: Schedule) -> CrontabSchedul
         )
         .one_or_none()
     )
-    return crontab or CrontabSchedule(**schedule.dict())
+    return crontab or CrontabSchedule(**schedule.model_dump())
 
 
 def schedule_task(
@@ -42,7 +44,9 @@ def schedule_task(
     """
     Schedule a task by adding a periodic task entry.
     """
-    crontab = get_crontab_schedule(session=session, schedule=scheduled_task.schedule)
+    crontab = get_crontab_schedule(
+        session=session, schedule=scheduled_task.schedule
+    )
     task = PeriodicTask(
         crontab=crontab,
         name=scheduled_task.name,
@@ -66,7 +70,11 @@ def update_task_enabled_status(
     Update task enabled status (if task is enabled or disabled).
     """
     try:
-        task = session.query(PeriodicTask).filter(PeriodicTask.id == periodic_task_id).one()
+        task = (
+            session.query(PeriodicTask)
+            .filter(PeriodicTask.id == periodic_task_id)
+            .one()
+        )
         task.enabled = enabled_status  # type: ignore [assignment]
         session.add(task)
 
@@ -85,7 +93,11 @@ def update_task(
     Update the details of a task including the crontab schedule
     """
     try:
-        task = session.query(PeriodicTask).filter(PeriodicTask.id == periodic_task_id).one()
+        task = (
+            session.query(PeriodicTask)
+            .filter(PeriodicTask.id == periodic_task_id)
+            .one()
+        )
 
         task.crontab = get_crontab_schedule(session, scheduled_task.schedule)
         task.name = scheduled_task.name  # type: ignore [assignment]
@@ -98,14 +110,22 @@ def update_task(
     return task
 
 
-def is_crontab_used(session: Session, crontab_schedule: CrontabSchedule) -> bool:
-    schedules = session.query(PeriodicTask).filter_by(crontab=crontab_schedule).all()
+def is_crontab_used(
+    session: Session, crontab_schedule: CrontabSchedule
+) -> bool:
+    schedules = (
+        session.query(PeriodicTask).filter_by(crontab=crontab_schedule).all()
+    )
     return True if schedules else False
 
 
 def delete_task(session: Session, periodic_task_id: int) -> PeriodicTask:
     try:
-        task = session.query(PeriodicTask).where(PeriodicTask.id == periodic_task_id).one()
+        task = (
+            session.query(PeriodicTask)
+            .where(PeriodicTask.id == periodic_task_id)
+            .one()
+        )
         session.delete(task)
         session.flush()
         if not is_crontab_used(session, task.crontab):

--- a/rdbbeat/data_models.py
+++ b/rdbbeat/data_models.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Hewlett Packard Enterprise Development LP
 # MIT License
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 
 class Schedule(BaseModel):
@@ -12,49 +12,59 @@ class Schedule(BaseModel):
     month_of_year: str = "*"
     timezone: str = "UTC"
 
-    @validator("minute")
+    @field_validator("minute")
     def minute_validation(cls, v: str) -> str:
         if "*" == v:
             return v
         elif not v.isdigit():
             raise ValueError(f"Minute: '{v}' is not a valid int")
-        assert int(v) >= 0 and int(v) < 60, "Minute value must range between 0 and 59"
+        assert (
+            int(v) >= 0 and int(v) < 60
+        ), "Minute value must range between 0 and 59"
         return v
 
-    @validator("hour")
+    @field_validator("hour")
     def hour_validation(cls, v: str) -> str:
         if "*" == v:
             return v
         elif not v.isdigit():
             raise ValueError(f"Hour: '{v}' is not a valid int")
-        assert int(v) >= 0 and int(v) < 24, "Hour value must range between 0 and 23"
+        assert (
+            int(v) >= 0 and int(v) < 24
+        ), "Hour value must range between 0 and 23"
         return v
 
-    @validator("day_of_week")
+    @field_validator("day_of_week")
     def day_of_week_validation(cls, v: str) -> str:
         if "*" == v:
             return v
         elif not v.isdigit():
             raise ValueError(f"Day of week: '{v}' is not a valid int")
-        assert int(v) >= 0 and int(v) < 7, "Day of the week value must range between 0 and 6"
+        assert (
+            int(v) >= 0 and int(v) < 7
+        ), "Day of the week value must range between 0 and 6"
         return v
 
-    @validator("day_of_month")
+    @field_validator("day_of_month")
     def day_of_month_validation(cls, v: str) -> str:
         if "*" == v:
             return v
         elif not v.isdigit():
             raise ValueError(f"Day of month: '{v}' is not a valid int")
-        assert int(v) > 0 and int(v) < 32, "Day of the month value must range between 1 and 31"
+        assert (
+            int(v) > 0 and int(v) < 32
+        ), "Day of the month value must range between 1 and 31"
         return v
 
-    @validator("month_of_year")
+    @field_validator("month_of_year")
     def month_of_year_validation(cls, v: str) -> str:
         if "*" == v:
             return v
         elif not v.isdigit():
             raise ValueError(f"Month: '{v}' is not a valid int")
-        assert int(v) > 0 and int(v) < 13, "Month of year value must range between 0 and 12"
+        assert (
+            int(v) > 0 and int(v) < 13
+        ), "Month of year value must range between 0 and 12"
         return v
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         "celery~=5.2",
         "sqlalchemy",
+        "SQLAlchemy-Utils",
         "alembic",
         "pydantic",
         "python-dotenv",

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -12,7 +12,7 @@ def test_schedule_pass():
         "day_of_month": "23",
         "month_of_year": "12",
     }
-    Schedule.parse_obj(schedule)
+    Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_minute_type():
@@ -23,8 +23,10 @@ def test_schedule_invalid_minute_type():
         "day_of_month": "23",
         "month_of_year": "12",
     }
-    with pytest.raises(ValueError, match="Minute: 'minute' is not a valid int"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValueError, match="Minute: 'minute' is not a valid int"
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_minute():
@@ -35,8 +37,10 @@ def test_schedule_invalid_minute():
         "day_of_month": "23",
         "month_of_year": "12",
     }
-    with pytest.raises(ValidationError, match="Minute value must range between 0 and 59"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValidationError, match="Minute value must range between 0 and 59"
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_hour_type():
@@ -48,7 +52,7 @@ def test_schedule_invalid_hour_type():
         "month_of_year": "12",
     }
     with pytest.raises(ValueError, match="Hour: 'h' is not a valid int"):
-        Schedule.parse_obj(schedule)
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_hour():
@@ -59,8 +63,10 @@ def test_schedule_invalid_hour():
         "day_of_month": "23",
         "month_of_year": "12",
     }
-    with pytest.raises(ValidationError, match="Hour value must range between 0 and 23"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValidationError, match="Hour value must range between 0 and 23"
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_day_of_week_type():
@@ -71,8 +77,10 @@ def test_schedule_invalid_day_of_week_type():
         "day_of_month": "23",
         "month_of_year": "12",
     }
-    with pytest.raises(ValueError, match="Day of week: 'day' is not a valid int"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValueError, match="Day of week: 'day' is not a valid int"
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_day_of_week():
@@ -83,8 +91,11 @@ def test_schedule_invalid_day_of_week():
         "day_of_month": "23",
         "month_of_year": "12",
     }
-    with pytest.raises(ValidationError, match="Day of the week value must range between 0 and 6"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValidationError,
+        match="Day of the week value must range between 0 and 6",
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_day_of_month_type():
@@ -95,8 +106,10 @@ def test_schedule_invalid_day_of_month_type():
         "day_of_month": "day",
         "month_of_year": "12",
     }
-    with pytest.raises(ValueError, match="Day of month: 'day' is not a valid int"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValueError, match="Day of month: 'day' is not a valid int"
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_day_of_month():
@@ -107,8 +120,11 @@ def test_schedule_invalid_day_of_month():
         "day_of_month": "32",
         "month_of_year": "12",
     }
-    with pytest.raises(ValidationError, match="Day of the month value must range between 1 and 31"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValidationError,
+        match="Day of the month value must range between 1 and 31",
+    ):
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_month_type():
@@ -120,7 +136,7 @@ def test_schedule_invalid_month_type():
         "month_of_year": "month",
     }
     with pytest.raises(ValueError, match="Month: 'month' is not a valid int"):
-        Schedule.parse_obj(schedule)
+        Schedule.model_validate(schedule)
 
 
 def test_schedule_invalid_month():
@@ -131,5 +147,8 @@ def test_schedule_invalid_month():
         "day_of_month": "23",
         "month_of_year": "0",
     }
-    with pytest.raises(ValidationError, match="Month of year value must range between 0 and 12"):
-        Schedule.parse_obj(schedule)
+    with pytest.raises(
+        ValidationError,
+        match="Month of year value must range between 0 and 12",
+    ):
+        Schedule.model_validate(schedule)


### PR DESCRIPTION
## Description

PydanticV2 has deprecated some of the decorators and methods used in the repo, generating warnings during testing.

## Types of changes

_Put an `x` in the boxes that apply._

- [ ] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [ ] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [x] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.

## Further Information

```
./usr/local/lib/python3.10/site-packages/rdbbeat/data_models.py:51
  /usr/local/lib/python3.10/site-packages/rdbbeat/data_models.py:51: PydanticDeprecatedSince20: Pydantic V1 style @validator validators are deprecated. You should migrate to Pydantic V2 style @field_validator validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.6/migration/
```
